### PR TITLE
fix failure of test_pane_order on fedora machines

### DIFF
--- a/tmuxp/testsuite/workspacebuilder.py
+++ b/tmuxp/testsuite/workspacebuilder.py
@@ -656,7 +656,7 @@ class PaneOrderingTest(TmuxTestCase):
       panes:
       - cd /usr/bin
       - cd /usr
-      - cd /sbin
+      - cd /usr/sbin
       - cd {HOME}
     """.format(
         HOME=os.path.realpath(os.path.expanduser('~'))
@@ -668,7 +668,7 @@ class PaneOrderingTest(TmuxTestCase):
         pane_paths = [
             '/usr/bin',
             '/usr',
-            '/sbin',
+            '/usr/sbin',
             os.path.realpath(os.path.expanduser('~'))
         ]
 


### PR DESCRIPTION
This pull request fixes the following issue:

When I run unit tests of tmuxp from current master on a fedora machine, test `test_pane_order` fails like this:

```
======================================================================
FAIL: test_pane_order (tmuxp.testsuite.workspacebuilder.PaneOrderingTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/martin/projects/tmuxp/tmuxp/testsuite/workspacebuilder.py", line  711, in test_pane_order
    self.assertEqual(p.get('pane_current_path'), pane_path)
AssertionError: u'/usr/sbin' != u'/sbin'
- /usr/sbin
? ----
+ /sbin
```

This mismatch is likely caused by the fact that `/sbin` directory is just a link to `/bin/sbin` (see [usr move feature](https://fedoraproject.org/wiki/Features/UsrMove). Since the primary purpose of this unit test is to check the order of panes , I propose to simply use different directory which is not a symlink.