### PR TITLE
A session name property for Session objects

### DIFF
--- a/tmuxp/session.py
+++ b/tmuxp/session.py
@@ -393,6 +393,10 @@ class Session(util.TmuxMappingObject, util.TmuxRelationalObject):
 
         return window_option[1]
 
+    @property
+    def name(self):
+        return self.get('session_name')
+
     def __repr__(self):
         return "%s(%s %s)" % (
             self.__class__.__name__,


### PR DESCRIPTION
I am not entirely familiar with the object, but using the API, I found it more intuitive to call `session.name` than to call `session.get('session_name')`. If you think that's a proper way to go, I can add similar properties.