### PR TITLE
Vendorize EnvironmentVarGuard, attempt to fix #121

### DIFF
--- a/tmuxp/_compat.py
+++ b/tmuxp/_compat.py
@@ -33,8 +33,6 @@ if PY2:
     from string import lower as ascii_lowercase
     import urlparse
 
-    from test import test_support as support
-
     exec('def reraise(tp, value, tb=None):\n raise tp, value, tb')
 
     def implements_to_string(cls):
@@ -72,8 +70,6 @@ else:
     import urllib.parse as urllib
     import urllib.parse as urlparse
     from urllib.request import urlretrieve
-
-    from test import support
 
     console_encoding = sys.__stdout__.encoding
 

--- a/tmuxp/testsuite/config.py
+++ b/tmuxp/testsuite/config.py
@@ -18,9 +18,8 @@ import unittest
 import kaptan
 
 from .helpers import TestCase
+from .util import EnvironmentVarGuard
 from .. import config, exc
-from .._compat import support
-
 
 
 logger = logging.getLogger(__name__)
@@ -1090,7 +1089,7 @@ class ConfigExpandEnvironmentVariables(TestCase, unittest.TestCase):
         sconfig = kaptan.Kaptan(handler='yaml')
         sconfig = sconfig.import_config(yaml_config).get()
 
-        with support.EnvironmentVarGuard() as env:
+        with EnvironmentVarGuard() as env:
             env.set(env_key, env_value)
             sconfig = config.expand(sconfig)
             self.assertEqual("%s/test" % env_value, sconfig['start_directory'])

--- a/tmuxp/testsuite/util.py
+++ b/tmuxp/testsuite/util.py
@@ -24,6 +24,40 @@ current_dir = os.path.realpath(os.path.dirname(__file__))
 fixtures_dir = os.path.realpath(os.path.join(current_dir, 'fixtures'))
 
 
+class EnvironmentVarGuard(object):
+
+    """Class to help protect the environment variable properly.  Can be used as
+    a context manager.
+      Vendorize to fix issue with Anaconda Python 2 not
+      including test module, see #121.
+    """
+
+    def __init__(self):
+        self._environ = os.environ
+        self._unset = set()
+        self._reset = dict()
+
+    def set(self, envvar, value):
+        if envvar not in self._environ:
+            self._unset.add(envvar)
+        else:
+            self._reset[envvar] = self._environ[envvar]
+        self._environ[envvar] = value
+
+    def unset(self, envvar):
+        if envvar in self._environ:
+            self._reset[envvar] = self._environ[envvar]
+            del self._environ[envvar]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *ignore_exc):
+        for envvar, value in self._reset.items():
+            self._environ[envvar] = value
+        for unset in self._unset:
+            del self._environ[unset]
+
 class TmuxVersionTest(TmuxTestCase):
 
     """Test the :meth:`has_required_tmux_version`."""


### PR DESCRIPTION
Anaconda 2.x doesn't bundle test module, vendorize the decorator used
from it. Slightly modified to change ``iteritems()`` to ``items()`` for
python 3 compatibility.