### PR TITLE
Optionally disable shell history suppression

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -241,6 +241,25 @@ JSON
 .. literalinclude:: ../examples/focus-window-and-panes.json
     :language: json
 
+Terminal History
+----------------
+
+tmuxp allows ``suppress_history: false`` to override the default command /
+suppression when building the workspace.
+This will add the ``shell_command`` to the bash history in the pane.
+
+YAML
+~~~~
+
+.. literalinclude:: ../examples/suppress-history.yaml
+    :language: yaml
+
+JSON
+~~~~
+
+.. literalinclude:: ../examples/suppress-history.json
+    :language: json
+
 Window Index
 ------------
 

--- a/examples/suppress-history.json
+++ b/examples/suppress-history.json
@@ -1,0 +1,42 @@
+{
+  "windows": [
+    {
+      "panes": [
+        "echo 'in the history!'"
+      ],
+      "focus": true,
+      "suppress_history": false,
+      "window_name": "appended"
+    },
+    {
+      "panes": [
+        "echo 'not in the history!'"
+      ],
+      "suppress_history": true,
+      "window_name": "suppressed"
+    },
+    {
+      "panes": [
+        "echo 'default not in the history!'"
+      ],
+      "window_name": "default"
+    },
+    {
+      "panes": [
+        {
+          "shell_command": "echo 'in the history!'",
+	  "suppress_history": false
+        },
+	{
+	  "shell_command": "echo 'not in the history!'",
+	  "suppress_history": true
+	},
+	{
+	  "shell_command": "echo 'default not in the history!'"
+	}
+      ],
+      "window_name": "mixed"
+    }
+  ],
+  "session_name": "suppress"
+}

--- a/examples/suppress-history.json
+++ b/examples/suppress-history.json
@@ -2,7 +2,7 @@
   "windows": [
     {
       "panes": [
-        "echo 'in the history!'"
+        "echo 'window in the history!'"
       ],
       "focus": true,
       "suppress_history": false,
@@ -10,33 +10,35 @@
     },
     {
       "panes": [
-        "echo 'not in the history!'"
+        "echo 'window not in the history!'"
       ],
       "suppress_history": true,
       "window_name": "suppressed"
     },
     {
       "panes": [
-        "echo 'default not in the history!'"
+        "echo 'session in the history!'"
       ],
       "window_name": "default"
     },
     {
       "panes": [
         {
-          "shell_command": "echo 'in the history!'",
+          "shell_command": "echo 'command in the history!'",
 	  "suppress_history": false
         },
 	{
-	  "shell_command": "echo 'not in the history!'",
+	  "shell_command": "echo 'command not in the history!'",
 	  "suppress_history": true
 	},
 	{
-	  "shell_command": "echo 'default not in the history!'"
+	  "shell_command": "echo 'window not in the history!'"
 	}
       ],
+      "suppress_history": true,
       "window_name": "mixed"
     }
   ],
+  "suppress_history": false,
   "session_name": "suppress"
 }

--- a/examples/suppress-history.yaml
+++ b/examples/suppress-history.yaml
@@ -1,27 +1,29 @@
 session_name: suppress
+suppress_history: false
 windows:
 - window_name: appended
   focus: true
   suppress_history: false
   panes:
-  - echo "in the history!"
+  - echo "window in the history!"
 
 - window_name: suppressed
   suppress_history: true
   panes:
-  - echo "not in the history!"
+  - echo "window not in the history!"
 
 - window_name: default
   panes:
-  - echo "default not in the history!"
+  - echo "session in the history!"
 
 - window_name: mixed
+  suppress_history: false
   panes:
   - shell_command:
-    - echo "in the history!"
+    - echo "command in the history!"
     suppress_history: false
   - shell_command:
-    - echo "not in the history!"
+    - echo "command not in the history!"
     suppress_history: true
   - shell_command:
-    - echo "default not in the history!"
+    - echo "window in the history!"

--- a/examples/suppress-history.yaml
+++ b/examples/suppress-history.yaml
@@ -1,0 +1,27 @@
+session_name: suppress
+windows:
+- window_name: appended
+  focus: true
+  suppress_history: false
+  panes:
+  - echo "in the history!"
+
+- window_name: suppressed
+  suppress_history: true
+  panes:
+  - echo "not in the history!"
+
+- window_name: default
+  panes:
+  - echo "default not in the history!"
+
+- window_name: mixed
+  panes:
+  - shell_command:
+    - echo "in the history!"
+    suppress_history: false
+  - shell_command:
+    - echo "not in the history!"
+    suppress_history: true
+  - shell_command:
+    - echo "default not in the history!"

--- a/tmuxp/config.py
+++ b/tmuxp/config.py
@@ -309,6 +309,11 @@ def trickle(sconf):
     else:
         session_start_directory = None
 
+    if 'suppress_history' in sconf:
+        suppress_history = sconf['suppress_history']
+    else:
+        suppress_history = None
+
     for windowconfig in sconf['windows']:
 
         # Prepend start_directory to relative window commands
@@ -324,6 +329,11 @@ def trickle(sconf):
                         session_start_directory, windowconfig['start_directory']
                     )
                     windowconfig['start_directory'] = window_start_path
+
+        # We only need to trickle to the window, workspace builder checks wconf
+        if suppress_history is not None:
+            if not 'suppress_history' in windowconfig:
+                windowconfig['suppress_history'] = suppress_history
 
         for paneconfig in windowconfig['panes']:
             commands_before = []

--- a/tmuxp/pane.py
+++ b/tmuxp/pane.py
@@ -85,6 +85,8 @@ class Pane(util.TmuxMappingObject, util.TmuxRelationalObject):
         :type cmd: str
         :param enter: Send enter after sending the input.
         :type enter: bool
+        :param suppress_history: Don't add these keys to the shell history
+        :type suppress_history: bool
 
         """
         prefix = ' ' if suppress_history else ''

--- a/tmuxp/pane.py
+++ b/tmuxp/pane.py
@@ -75,7 +75,7 @@ class Pane(util.TmuxMappingObject, util.TmuxRelationalObject):
 
         return self.server.cmd(cmd, *args, **kwargs)
 
-    def send_keys(self, cmd, enter=True):
+    def send_keys(self, cmd, enter=True, suppress_history=True):
         """``$ tmux send-keys`` to the pane.
 
         A leading space character is added to cmd to avoid polluting the
@@ -87,7 +87,8 @@ class Pane(util.TmuxMappingObject, util.TmuxRelationalObject):
         :type enter: bool
 
         """
-        self.cmd('send-keys', ' ' + cmd)
+        prefix = ' ' if suppress_history else ''
+        self.cmd('send-keys', prefix + cmd)
 
         if enter:
             self.enter()

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -261,8 +261,15 @@ class WorkspaceBuilder(object):
             if 'layout' in wconf:
                 w.select_layout(wconf['layout'])
 
+            if 'suppress_history' in pconf:
+                suppress = pconf['suppress_history']
+            elif 'suppress_history' in wconf:
+                suppress = wconf['suppress_history']
+            else:
+                suppress = True
+
             for cmd in pconf['shell_command']:
-                p.send_keys(cmd)
+                p.send_keys(cmd, suppress_history=suppress)
 
             if 'focus' in pconf and pconf['focus']:
                 w.select_pane(p['pane_id'])


### PR DESCRIPTION
This PR closes #144.

Adds the `suppress_history` option to override the default shell history suppression, for the `workspace_builder` only. The flag can be set at the session, window, or pane level, and defaults to `True` (the only existing option before this PR).

Documentation and examples have been added as well.