### PR TITLE
Patching unittest timing for shell history suppression

### DIFF
--- a/tmuxp/testsuite/workspacebuilder.py
+++ b/tmuxp/testsuite/workspacebuilder.py
@@ -238,7 +238,7 @@ class SuppressHistoryTest(TmuxTestCase):
 
         builder = WorkspaceBuilder(sconf=sconfig)
         builder.build(session=self.session)
-        time.sleep(0.2) # give .bashrc, etc. time to load
+        time.sleep(0.3) # give .bashrc, etc. time to load
 
         s.server._update_windows()
         for w in s.windows:
@@ -250,7 +250,7 @@ class SuppressHistoryTest(TmuxTestCase):
                 # Print the last-in-history command in the pane
                 self.session.cmd('send-keys', ' fc -ln -1')
                 self.session.cmd('send-keys', 'Enter')
-                time.sleep(0.01) # give fc time to run
+                time.sleep(0.1) # give fc time to run
 
                 # Get the contents of the pane
                 self.session.cmd('capture-pane')
@@ -269,7 +269,7 @@ class SuppressHistoryTest(TmuxTestCase):
                     self.assertNotEqual(sent_cmd, history_cmd)
                 # Something went wrong
                 else:
-                    self.assertTrue(False)
+                    self.fail("Unknown sent command: [%s]" % sent_cmd)
 
 
 class WindowOptions(TmuxTestCase):


### PR DESCRIPTION
Refers to [the request](https://github.com/tony/tmuxp/pull/145#issuecomment-219497967) in #145. 

Since #146 is already merged, I'm not sure if you want me to squash (since this patch is a single commit). If you meant you wanted to revert master and re-merge #146, let me know and I can squash that one including this patch.