### PR TITLE
chore: add a missing space in error message

### DIFF
--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -172,7 +172,7 @@ def resolve_config(config, config_dir=None):
             ]
             if not len(candidates):
                 file_error = (
-                    'config not found in config dir (yaml/yml/json) %s'
+                    'config not found in config dir (yaml/yml/json) %s '
                     'for name' % (config_dir))
         else:
             candidates = [


### PR DESCRIPTION
nothing fancy, just a missing space