### PR TITLE
Fix typo in cli import docs

### DIFF
--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -83,7 +83,7 @@ From teamocil
 
 ::
 
-    tmuxp import tmuxinator /path/to/file.{json,yaml}
+    tmuxp import teamocil /path/to/file.{json,yaml}
 
 .. _import_tmuxinator:
 


### PR DESCRIPTION
The import section of the cli docs had `tmuxp import tmuxinator` under both the `teamocil` and `tmuxinator` sections

![screen shot 2016-11-17 at 10 59 53 am](https://cloud.githubusercontent.com/assets/955190/20396708/171196ec-acb5-11e6-93db-5b8da745f22a.png)
