### PR TITLE
Ignore bash prompt when comparing history command.

### DIFF
--- a/tests/test_workspacebuilder.py
+++ b/tests/test_workspacebuilder.py
@@ -148,10 +148,10 @@ def test_suppress_history(session):
         {'window_name': 'isMissing'}).attached_pane
 
     def assertHistory(cmd, hist):
-        return 'inHistory' in cmd and cmd == hist
+        return 'inHistory' in cmd and cmd.endswith(hist)
 
     def assertIsMissing(cmd, hist):
-        return 'isMissing' in cmd and cmd != hist
+        return 'isMissing' in cmd and not cmd.endswith(hist)
 
     for p, assertCase in [
         (inHistoryPane, assertHistory,), (isMissingPane, assertIsMissing,)


### PR DESCRIPTION
The `sent_cmd` includes the bash prompt on the captured line (or at
least could depending on timing) so compare with `endswith()` to ignore
any prefix containing the prompt string.