### PR TITLE
Implement `options_after` window option

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -301,6 +301,25 @@ JSON
 .. literalinclude:: ../examples/options.json
     :language: json
 
+Set window options after pane creation
+--------------------------------------
+
+Apply window options after panes have been created. Useful for
+``synchronize-panes`` option after executing individual commands in each
+pane during creation.
+
+YAML
+~~~~
+
+.. literalinclude:: ../examples/2-pane-synchronized.yaml
+    :language: yaml
+
+JSON
+~~~~
+
+.. literalinclude:: ../examples/2-pane-synchronized.json
+    :language: json
+
 Main pane height
 ----------------
 

--- a/examples/2-pane-synchronized.json
+++ b/examples/2-pane-synchronized.json
@@ -1,0 +1,15 @@
+{
+  "session_name": "2-pane-synchronized",
+  "windows": [
+    {
+      "window_name": "Two synchronized panes",
+      "panes": [
+        "ssh server1",
+        "ssh server2"
+      ],
+      "options_after": {
+        "synchronize-panes": true
+      }
+    }
+  ]
+}

--- a/examples/2-pane-synchronized.yaml
+++ b/examples/2-pane-synchronized.yaml
@@ -1,0 +1,8 @@
+session_name: 2-pane-synchronized
+windows:
+  - window_name: Two synchronized panes
+    panes:
+    - ssh server1
+    - ssh server2
+    options_after:
+      synchronize-panes: on

--- a/tests/fixtures/workspacebuilder/window_options_after.yaml
+++ b/tests/fixtures/workspacebuilder/window_options_after.yaml
@@ -1,9 +1,9 @@
 session_name: tmuxp test window_options_after
 options:
-  default-shell: /bin/sh
-  default-command: /bin/sh
+  default-shell: /bin/bash
 windows:
   - window_name: test
+    suppress_history: false
     panes:
     - echo 0
     - echo 1

--- a/tests/fixtures/workspacebuilder/window_options_after.yaml
+++ b/tests/fixtures/workspacebuilder/window_options_after.yaml
@@ -1,0 +1,11 @@
+session_name: tmuxp test window_options_after
+options:
+  default-shell: /bin/sh
+  default-command: /bin/sh
+windows:
+  - window_name: test
+    panes:
+    - echo 0
+    - echo 1
+    options_after:
+      synchronize-panes: on

--- a/tests/test_workspacebuilder.py
+++ b/tests/test_workspacebuilder.py
@@ -280,7 +280,7 @@ def test_window_options_after(session):
         pane.enter()                # in each iteration
         assert_last_line(pane, str(i))
 
-    session.cmd('send-keys', 'echo moo')
+    session.cmd('send-keys', ' echo moo')
     session.cmd('send-keys', 'Enter')
 
     for pane in session.attached_window.panes:

--- a/tests/test_workspacebuilder.py
+++ b/tests/test_workspacebuilder.py
@@ -259,6 +259,34 @@ def test_window_options(session):
         w.select_layout(wconf['layout'])
 
 
+def test_window_options_after(session):
+    yaml_config = loadfixture("workspacebuilder/window_options_after.yaml")
+    s = session
+    sconfig = kaptan.Kaptan(handler='yaml')
+    sconfig = sconfig.import_config(yaml_config).get()
+    sconfig = config.expand(sconfig)
+
+    builder = WorkspaceBuilder(sconf=sconfig)
+    builder.build(session=session)
+
+    def assert_last_line(p, s):
+        # Print output for easier debugging if test fails
+        print('\n'.join(p.cmd('capture-pane', '-p').stdout))
+        assert p.cmd('capture-pane', '-p').stdout[-2] == s
+
+    for i, pane in enumerate(session.attached_window.panes):
+        assert_last_line(pane, str(i))
+        pane.cmd('send-keys', 'Up') # Will repeat echo
+        pane.enter()                # in each iteration
+        assert_last_line(pane, str(i))
+
+    session.cmd('send-keys', 'echo moo')
+    session.cmd('send-keys', 'Enter')
+
+    for pane in session.attached_window.panes:
+        assert_last_line(pane, 'moo')
+
+
 def test_window_shell(session):
     yaml_config = loadfixture("workspacebuilder/window_shell.yaml")
     s = session

--- a/tests/test_workspacebuilder.py
+++ b/tests/test_workspacebuilder.py
@@ -274,6 +274,8 @@ def test_window_options_after(session):
         correct = False
         for _ in range(10):
             pane_out = p.cmd('capture-pane', '-p', '-J').stdout
+            # delete trailing empty lines for tmux 1.8...
+            while not pane_out[-1].strip(): pane_out.pop()
             if len(pane_out) > 1 and pane_out[-2].strip() == s:
                 correct = True
                 break

--- a/tmuxp/workspacebuilder.py
+++ b/tmuxp/workspacebuilder.py
@@ -188,6 +188,8 @@ class WorkspaceBuilder(object):
             if 'focus' in wconf and wconf['focus']:
                 focus = w
 
+            self.config_after_window(w, wconf)
+
             if focus_pane:
                 focus_pane.select_pane()
 
@@ -307,6 +309,14 @@ class WorkspaceBuilder(object):
             w.server._update_panes()
 
             yield p, pconf
+
+    """
+    Applies window configurations relevant after window and pane creation.
+    """
+    def config_after_window(self, w, wconf):
+        if 'options_after' in wconf and isinstance(wconf['options_after'], dict):
+            for key, val in wconf['options_after'].items():
+                w.set_window_option(key, val)
 
 
 def freeze(session):


### PR DESCRIPTION
Created new method `config_after_window()` that applies relevant configurations after windows and panes have been created.

Currently, it only knows the `options_after` option. This is useful for setting `synchronize-panes: on` *after* pane creation and shell command execution.

The same could be done for panes, but I don't know of an application for that at the moment.