### PR TITLE
When loading, get the config canonical file path

### DIFF
--- a/tmuxp/cli.py
+++ b/tmuxp/cli.py
@@ -218,6 +218,8 @@ def load_workspace(
     :param type: string
 
     """
+    # get the canonical path, eliminating any symlinks
+    config_file = os.path.realpath(config_file)
 
     sconfig = kaptan.Kaptan()
     sconfig = sconfig.import_config(config_file).get()


### PR DESCRIPTION
Fix issue when config files are symlinks in `~/.tmuxp`.

For example,
```sh
$ tree ~/.tmuxp
/Users/bob/.tmuxp
├── hooray-api.yml -> /Users/bob/code/python/hooray/api/.tmuxp.yml
└── hooray-web.yml -> /Users/bob/code/python/hooray/web/.tmuxp.yml
```

Once loaded, it is expected for `/Users/bob/code/python/hooray/...` to be the current directory, specially when using `start_directory: ./` within the configuration file.
Before this patch, the current directory will improperly resolve to `/Users/bob/.tmuxp`.