### PR TITLE
bugfix bad assignment in hint

### DIFF
--- a/tmuxp/util.py
+++ b/tmuxp/util.py
@@ -70,7 +70,7 @@ def oh_my_zsh_auto_title():
                 os.environ.get('DISABLE_AUTO_TITLE') == "false"
             ):
                 print('Please set:\n\n'
-                      '\texport DISABLE_AUTO_TITLE = \'true\'\n\n'
+                      '\texport DISABLE_AUTO_TITLE=\'true\'\n\n'
                       'in ~/.zshrc or where your zsh profile is stored.\n'
                       'Remember the "export" at the beginning!\n\n'
                       'Then create a new shell or type:\n\n'


### PR DESCRIPTION
First time to run tmuxp, I got:

```
Please set:

	export DISABLE_AUTO_TITLE = 'true'

in ~/.zshrc or where your zsh profile is stored.
Remember the "export" at the beginning!

Then create a new shell or type:

	$ source ~/.zshrc
```

But the export syntax not working

```
$ export foo = 'bar'
zsh: bad assignment
$ export foo='bar'
$
```
